### PR TITLE
Fix bug: if any post has no text, it crashes (iwa function)

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ function iwa({
                             likes: el['node']['edge_liked_by']['count'],
                             comments: el['node']['edge_media_to_comment']['count'],
                             link: 'https://www.instagram.com/p/' + el['node']['shortcode'] + '/',
-                            text: el['node']['edge_media_to_caption']['edges'][0]['node']['text']
+                            text: el['node']['edge_media_to_caption']['edges'][0]?.['node']['text']
                         }
                         if (image) obj.image = image;
                         return obj


### PR DESCRIPTION
Using the iwa function will crash the whole thing if any of the posts of the instagram user we searched has no caption or no text (Example https://www.instagram.com/p/CmfebZmpg7y/ see OP hasnt written any text)

Getting the following error because el['node']['edge_media_to_caption']['edges'] returns an empty array:
![Screenshot_1](https://user-images.githubusercontent.com/57531380/217618542-7468bf31-c70a-4baf-8cf1-f012b0731dd6.jpg)

Quick fix: Using optional chaining so it returns undefined for the posts with no text, without crashing the app.
text: el['node']['edge_media_to_caption']['edges'][0]**?.**['node']['text']